### PR TITLE
fix trim deprecated

### DIFF
--- a/qris.php
+++ b/qris.php
@@ -37,8 +37,9 @@ if (empty($tax)) {
     $uang .= $tax."5802ID";
 }
 
-$fix = trim($step2[0]).$uang.trim($step2[1]);
+$fix = trim($step2[0] ?? '') . $uang . trim($step2[1] ?? '');
 $fix .= ConvertCRC16($fix);
+
 
 echo "\n[+] Result: $fix\n";
 


### PR DESCRIPTION
memastikan agar trim($step2[0]) dan trim($step2[1]) tidak memicu pesan deprecated ketika salah satu elemen array $step2 bernilai null